### PR TITLE
Use ruby:3.2.1-alpine3.17 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM ruby:3.2.1-alpine3.17
 
 ENV REVIEWDOG_VERSION v0.10.0
 


### PR DESCRIPTION
This fixes the `rubocop-ast` dependency issue with the standardrb action on PRX